### PR TITLE
ci: check generated ABIs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,19 @@ permissions:
 
 name: release-please
 jobs:
+  check-abis:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # pin@v3
+        with:
+          submodules: recursive
+
+      - uses: aave-dao/github-workflows/.github/actions/foundry-setup@main
+
+      - uses: aave-dao/github-workflows/.github/actions/setup-node@main
+
+      - run: npm run check:abis
+
   test-solidity:
     uses: aave-dao/github-workflows/.github/workflows/foundry-test.yml@main
     secrets:
@@ -29,6 +42,7 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     needs:
+      - check-abis
       - test-solidity
       - test-node
     outputs:
@@ -124,6 +138,7 @@ jobs:
   release-node-alpha:
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
     needs:
+      - check-abis
       - test-solidity
       - test-node
     uses: aave-dao/github-workflows/.github/workflows/release-node-alpha.yml@main

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "check:verification": "tsx scripts/verifyVerified.ts",
     "check:sanity": "tsx scripts/sanity.ts",
     "generate:abis": "tsx scripts/generateABIs.ts && prettier --write 'src/ts/abis/**/*.ts'",
+    "check:abis": "tsx scripts/checkGeneratedABIs.ts",
     "generate:safe": "tsx scripts/generateSafeCSV.ts",
     "generate:addresses": "tsx scripts/generateAddresses.ts && npm run generate:safe && npm run prettier",
     "start": "tsx scripts/generateABIs.ts && tsx scripts/generateAddresses.ts && npm run prettier",

--- a/scripts/checkGeneratedABIs.ts
+++ b/scripts/checkGeneratedABIs.ts
@@ -1,0 +1,42 @@
+import {execFileSync} from 'node:child_process';
+import {mkdtempSync, readFileSync, readdirSync, rmSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {generateABIs} from 'scripts/generateABIs';
+
+const ABI_DIRECTORY = './src/ts/abis';
+const generatedDirectory = mkdtempSync(join(tmpdir(), 'aave-address-book-abis-'));
+
+async function checkGeneratedABIs() {
+  try {
+    await generateABIs(generatedDirectory);
+    execFileSync('npx', [
+      'prettier',
+      '--config',
+      '.prettierrc',
+      '--write',
+      join(generatedDirectory, '*.ts'),
+    ]);
+
+    const currentFiles = readdirSync(ABI_DIRECTORY).sort();
+    const generatedFiles = readdirSync(generatedDirectory).sort();
+    const changedFiles = generatedFiles.filter(
+      (file) =>
+        !currentFiles.includes(file) ||
+        readFileSync(join(ABI_DIRECTORY, file), 'utf8') !==
+          readFileSync(join(generatedDirectory, file), 'utf8'),
+    );
+    const extraFiles = currentFiles.filter((file) => !generatedFiles.includes(file));
+    const differences = [...changedFiles, ...extraFiles];
+
+    if (differences.length) {
+      throw new Error(
+        `Generated TypeScript ABIs are out of sync: ${differences.sort().join(', ')}`,
+      );
+    }
+  } finally {
+    rmSync(generatedDirectory, {recursive: true, force: true});
+  }
+}
+
+checkGeneratedABIs();


### PR DESCRIPTION
Committed TypeScript ABIs can drift from their authoritative Solidity interfaces without failing the existing test jobs.

Add a non-mutating ABI consistency command that generates into a temporary directory and reports missing, extra, or changed files. Run it in the release workflow using the shared Aave DAO Foundry setup, and require it before alpha or production releases.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
