### PR TITLE
fix(ci): use aave-dao foundry-setup action, stale foundry-toolchain pin breaks foundryup

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@8789b3e21e6c11b2697f5eb56eddae542f746c10 # pin@v1
+        uses: foundry-rs/foundry-toolchain@master
         with:
           version: nightly
 

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -31,8 +31,6 @@ jobs:
 
       - name: Install Foundry
         uses: aave-dao/github-workflows/.github/actions/foundry-setup@main
-        with:
-          FOUNDRY_VERSION: nightly
 
       - uses: aave-dao/github-workflows/.github/actions/setup-node@main
 

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -30,9 +30,9 @@ jobs:
           fetch-depth: 0
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@master
+        uses: aave-dao/github-workflows/.github/actions/foundry-setup@main
         with:
-          version: nightly
+          FOUNDRY_VERSION: nightly
 
       - uses: aave-dao/github-workflows/.github/actions/setup-node@main
 


### PR DESCRIPTION
## Problem

The `Update library` workflow ([latest run](https://github.com/aave-dao/aave-address-book/actions/runs/33004040200)) fails at the Install Foundry step:

```
##[error]/home/runner/.foundry/bin/foundryup: cannot execute binary file
##[error]Error: Command failed: bash "/home/runner/.foundry/bin/foundryup" --install nightly
```

The pinned commit of `foundry-rs/foundry-toolchain` (`8789b3e2`) predates the foundryup binary distribution change, so it tries to run the new foundryup binary through bash.

## Fix

Use `aave-dao/github-workflows/.github/actions/foundry-setup@main` instead of pinning `foundry-rs/foundry-toolchain` directly, matching how `setup-node` is already referenced in the same workflow. It includes the fix recently done to the foundryup tool chain issue in its [latest release](https://github.com/aave-dao/github-workflows/pull/7). The shared action uses foundry-toolchain v1.9.1, which handles the new foundryup distribution, and defaults to the stable foundry version.

Note: the `release-please` failure on main is unrelated (`no pull requests found for branch "main"`).