### PR TITLE
refactor: update ABI generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "prettier": "prettier --write 'src/**/*.{sol,ts}'",
     "check:verification": "tsx scripts/verifyVerified.ts",
     "check:sanity": "tsx scripts/sanity.ts",
-    "generate:abis": "tsx scripts/generateABIs.ts && npm run prettier",
+    "generate:abis": "tsx scripts/generateABIs.ts && prettier --write 'src/ts/abis/**/*.ts'",
     "generate:safe": "tsx scripts/generateSafeCSV.ts",
     "generate:addresses": "tsx scripts/generateAddresses.ts && npm run generate:safe && npm run prettier",
     "start": "tsx scripts/generateABIs.ts && tsx scripts/generateAddresses.ts && npm run prettier",

--- a/scripts/configs/abis.ts
+++ b/scripts/configs/abis.ts
@@ -1,114 +1,202 @@
-import {governanceConfigMainnet} from 'scripts/configs/governance/ethereum';
-import {mainnetProtoV3Pool} from 'scripts/configs/pools/ethereum';
-
 /**
- * @dev An abi interface is either a forge identifier (the file name / path is used as the export name)
- * or an explicit `{path, name}` pair when the export name must differ from the interface name to avoid
- * collisions (e.g. the V4 `IAaveOracle` interface is exported as `IAaveOracleV4`).
+ * @dev A Solidity interface compiled by Forge into a TypeScript ABI.
  */
-export type AbiInterface = string | {path: string; name: string};
+export type AbiInterface = {name: string; target: string};
 
 /**
- * @dev Resolves an abi interface entry to the forge path passed to `forge inspect` and the name used
- * for the generated file and its `_ABI` export.
- */
-export function resolveAbiInterface(entry: AbiInterface): {path: string; name: string} {
-  if (typeof entry === 'string') {
-    const match = entry.match(/\/([^/]+)\.sol$/);
-    return {path: entry, name: match ? match[1] : entry};
-  }
-  return entry;
-}
-
-/**
- * @dev These abis can be inferred directly from code as they exist as a dependency
- * For contracts that are not unique, the path needs to be prefixed
+ * @dev Solidity is authoritative for every entry in this list. `generate:abis` compiles each target
+ * and writes its TypeScript ABI to `src/ts/abis`.
  */
 export const ABI_INTERFACES: AbiInterface[] = [
-  'ICollector',
-  'lib/aave-v3-origin/src/contracts/extensions/v3-config-engine/IAaveV3ConfigEngine.sol',
-  'IVotingMachineWithProofs',
-  'IVotingStrategy',
-  'IVotingPortal',
-  'IGovernancePowerStrategy',
-  'IDataWarehouse',
-  'IExecutorWithTimelock',
-  'IAToken',
-  'IExecutor',
-  'ICrossChainController',
-  'IWithGuardian',
-  'lib/aave-v3-origin/lib/solidity-utils/src/contracts/utils/interfaces/IRescuable.sol',
-  'lib/aave-v3-origin/src/contracts/interfaces/IACLManager.sol',
-  'ILendingPool',
-  'ILendingPoolAddressesProvider',
-  'ILendingPoolConfigurator',
-  'IStakeToken',
-  {path: 'lib/aave-v4/src/hub/interfaces/IHub.sol', name: 'IHubV4'},
-  {path: 'lib/aave-v4/src/spoke/interfaces/ISpoke.sol', name: 'ISpokeV4'},
-  {path: 'lib/aave-v4/src/spoke/interfaces/ITokenizationSpoke.sol', name: 'ITokenizationSpokeV4'},
-  {path: 'lib/aave-v4/src/spoke/interfaces/IAaveOracle.sol', name: 'IAaveOracleV4'},
-  'lib/aave-v4/src/hub/interfaces/IHubConfigurator.sol',
-  'lib/aave-v4/src/spoke/interfaces/ISpokeConfigurator.sol',
-  'lib/aave-v4/src/config-engine/interfaces/IAaveV4ConfigEngine.sol',
-  'lib/aave-v4/src/position-manager/interfaces/IGiverPositionManager.sol',
-  'lib/aave-v4/src/position-manager/interfaces/ITakerPositionManager.sol',
-  'lib/aave-v4/src/position-manager/interfaces/IConfigPositionManager.sol',
-  'lib/aave-v4/src/position-manager/interfaces/INativeTokenGateway.sol',
-  'lib/aave-v4/src/position-manager/interfaces/ISignatureGateway.sol',
-  'lib/aave-v4/src/access/interfaces/IAccessManagerEnumerable.sol',
-];
-
-/**
- * @dev These abis cannot be inferred as they don't exist as a dependency on this repo.
- * Therefore we use forge download & forge inspect to fetch them from on-chain contracts
- */
-export const DOWNLOAD_ABI_INTERFACES = [
+  {name: 'ICollector', target: 'lib/aave-v3-origin/src/contracts/treasury/ICollector.sol'},
   {
-    address: governanceConfigMainnet.ADDRESSES.PC_DATA_HELPER,
-    name: 'IPayloadsControllerDataHelper',
+    name: 'IAaveV3ConfigEngine',
+    target: 'lib/aave-v3-origin/src/contracts/extensions/v3-config-engine/IAaveV3ConfigEngine.sol',
   },
   {
-    address: governanceConfigMainnet.ADDRESSES.GOV_DATA_HELPER,
-    name: 'IGovernanceDataHelper',
+    name: 'IVotingMachineWithProofs',
+    target: 'src/governance-v3/IVotingMachineWithProofs.sol:IVotingMachineWithProofs',
+  },
+  {name: 'IVotingStrategy', target: 'src/governance-v3/IVotingStrategy.sol:IVotingStrategy'},
+  {name: 'IVotingPortal', target: 'src/governance-v3/IVotingPortal.sol:IVotingPortal'},
+  {
+    name: 'IGovernancePowerStrategy',
+    target: 'src/governance-v3/IGovernancePowerStrategy.sol:IGovernancePowerStrategy',
+  },
+  {name: 'IDataWarehouse', target: 'src/governance-v3/IDataWarehouse.sol:IDataWarehouse'},
+  {
+    name: 'IExecutorWithTimelock',
+    target: 'src/common/IExecutorWithTimelock.sol:IExecutorWithTimelock',
+  },
+  {name: 'IAToken', target: 'lib/aave-v3-origin/src/contracts/interfaces/IAToken.sol'},
+  {name: 'IExecutor', target: 'src/governance-v3/IExecutor.sol:IExecutor'},
+  {
+    name: 'ICrossChainController',
+    target: 'src/common/ICrossChainController.sol:ICrossChainController',
   },
   {
-    address: governanceConfigMainnet.ADDRESSES.META_DELEGATE_HELPER,
-    name: 'IMetaDelegateHelper',
+    name: 'IWithGuardian',
+    target:
+      'lib/aave-v3-origin/lib/solidity-utils/src/contracts/access-control/interfaces/IWithGuardian.sol',
   },
   {
-    address: governanceConfigMainnet.ADDRESSES.VM_DATA_HELPER,
-    name: 'IVotingMachineDataHelper',
+    name: 'IRescuable',
+    target: 'lib/aave-v3-origin/lib/solidity-utils/src/contracts/utils/interfaces/IRescuable.sol',
+  },
+  {name: 'IACLManager', target: 'lib/aave-v3-origin/src/contracts/interfaces/IACLManager.sol'},
+  {name: 'ILendingPool', target: 'src/AaveV2.sol:ILendingPool'},
+  {
+    name: 'ILendingPoolAddressesProvider',
+    target: 'src/AaveV2.sol:ILendingPoolAddressesProvider',
   },
   {
-    address: mainnetProtoV3Pool.additionalAddresses.UI_POOL_DATA_PROVIDER,
-    name: 'IUiPoolDataProvider',
+    name: 'ILendingPoolConfigurator',
+    target: 'src/AaveV2.sol:ILendingPoolConfigurator',
+  },
+  {name: 'IStakeToken', target: 'src/common/IStakeToken.sol:IStakeToken'},
+  {name: 'IHubV4', target: 'lib/aave-v4/src/hub/interfaces/IHub.sol'},
+  {name: 'ISpokeV4', target: 'lib/aave-v4/src/spoke/interfaces/ISpoke.sol'},
+  {
+    name: 'ITokenizationSpokeV4',
+    target: 'lib/aave-v4/src/spoke/interfaces/ITokenizationSpoke.sol',
   },
   {
-    address: mainnetProtoV3Pool.additionalAddresses.RISK_STEWARD,
-    name: 'IRiskSteward',
+    name: 'IAaveOracleV4',
+    target: 'lib/aave-v4/src/spoke/interfaces/IAaveOracle.sol',
   },
   {
-    address: '0x5D4Aa78B08Bc7C530e21bf7447988b1Be7991322',
-    name: 'IAaveToken',
+    name: 'IHubConfigurator',
+    target: 'lib/aave-v4/src/hub/interfaces/IHubConfigurator.sol',
   },
   {
-    address: '0x0fE58FE1CaA69951dC924A8c222bE19013B89476',
-    name: 'IStkAaveToken',
+    name: 'ISpokeConfigurator',
+    target: 'lib/aave-v4/src/spoke/interfaces/ISpokeConfigurator.sol',
   },
   {
-    address: '0x366AE337897223AEa70e3EBe1862219386f20593',
+    name: 'IAaveV4ConfigEngine',
+    target: 'lib/aave-v4/src/config-engine/interfaces/IAaveV4ConfigEngine.sol',
+  },
+  {
+    name: 'IGiverPositionManager',
+    target: 'lib/aave-v4/src/position-manager/interfaces/IGiverPositionManager.sol',
+  },
+  {
+    name: 'ITakerPositionManager',
+    target: 'lib/aave-v4/src/position-manager/interfaces/ITakerPositionManager.sol',
+  },
+  {
+    name: 'IConfigPositionManager',
+    target: 'lib/aave-v4/src/position-manager/interfaces/IConfigPositionManager.sol',
+  },
+  {
+    name: 'INativeTokenGateway',
+    target: 'lib/aave-v4/src/position-manager/interfaces/INativeTokenGateway.sol',
+  },
+  {
+    name: 'ISignatureGateway',
+    target: 'lib/aave-v4/src/position-manager/interfaces/ISignatureGateway.sol',
+  },
+  {
+    name: 'IAccessManagerEnumerable',
+    target: 'lib/aave-v4/src/access/interfaces/IAccessManagerEnumerable.sol',
+  },
+  {
+    name: 'AggregatorInterface',
+    target: 'src/interfaces/AggregatorInterface.sol:AggregatorInterface',
+  },
+  {
     name: 'IATokenWithDelegation',
+    target: 'src/interfaces/IATokenWithDelegation.sol:IATokenWithDelegation',
   },
   {
-    address: '0x85C3371044e49782DbE3dC23de1D77a078aFb5d0',
+    name: 'IAaveOracle',
+    target: 'lib/aave-v3-origin/src/contracts/interfaces/IAaveOracle.sol',
+  },
+  {name: 'IAaveToken', target: 'src/interfaces/IAaveToken.sol:IAaveToken'},
+  {
+    name: 'IDefaultInterestRateStrategy',
+    target: 'src/AaveV2.sol:IDefaultInterestRateStrategy',
+  },
+  {
+    name: 'IERC20',
+    target: 'src/interfaces/IERC20.sol:IERC20',
+  },
+  {
+    name: 'IERC20Detailed',
+    target: 'src/interfaces/IERC20Detailed.sol:IERC20Detailed',
+  },
+  {
+    name: 'IGovernanceCore',
+    target: 'src/governance-v3/IGovernanceCore.sol:IGovernanceCore',
+  },
+  {
+    name: 'IGovernanceDataHelper',
+    target: 'src/interfaces/IGovernanceDataHelper.sol:IGovernanceDataHelper',
+  },
+  {
+    name: 'IMetaDelegateHelper',
+    target: 'src/interfaces/IMetaDelegateHelper.sol:IMetaDelegateHelper',
+  },
+  {name: 'IOwnable', target: 'src/common/IOwnable.sol:IOwnable'},
+  {
+    name: 'IPayloadsControllerCore',
+    target: 'src/governance-v3/IPayloadsControllerCore.sol:IPayloadsControllerCore',
+  },
+  {
+    name: 'IPayloadsControllerDataHelper',
+    target: 'src/interfaces/IPayloadsControllerDataHelper.sol:IPayloadsControllerDataHelper',
+  },
+  {name: 'IPool', target: 'src/interfaces/IPool.sol:IPool'},
+  {
+    name: 'IPoolAddressesProvider',
+    target: 'lib/aave-v3-origin/src/contracts/interfaces/IPoolAddressesProvider.sol',
+  },
+  {
+    name: 'IPoolConfigurator',
+    target: 'src/interfaces/IPoolConfigurator.sol:IPoolConfigurator',
+  },
+  {
+    name: 'IRewardsController',
+    target: 'lib/aave-v3-origin/src/contracts/rewards/interfaces/IRewardsController.sol',
+  },
+  {name: 'IRiskSteward', target: 'src/interfaces/IRiskSteward.sol:IRiskSteward'},
+  {
+    name: 'IStataTokenFactory',
+    target:
+      'lib/aave-v3-origin/src/contracts/extensions/stata-token/interfaces/IStataTokenFactory.sol',
+  },
+  {
+    name: 'IStataTokenV2',
+    target: 'lib/aave-v3-origin/src/contracts/extensions/stata-token/interfaces/IStataTokenV2.sol',
+  },
+  {
+    name: 'IStaticATokenFactory',
+    target: 'src/interfaces/IStaticATokenFactory.sol:IStaticATokenFactory',
+  },
+  {
+    name: 'IStaticATokenLM',
+    target: 'src/interfaces/IStaticATokenLM.sol:IStaticATokenLM',
+  },
+  {name: 'IStkAaveToken', target: 'src/interfaces/IStkAaveToken.sol:IStkAaveToken'},
+  {
+    name: 'IUiPoolDataProvider',
+    target: 'src/interfaces/IUiPoolDataProvider.sol:IUiPoolDataProvider',
+  },
+  {name: 'IUmbrella', target: 'src/common/IUmbrella.sol:IUmbrella'},
+  {
     name: 'IUmbrellaRewardsController',
+    target: 'src/interfaces/IUmbrellaRewardsController.sol:IUmbrellaRewardsController',
   },
   {
-    address: '0xDE00aC600900ae5833F0aDbf601A1DAEbD16B482',
-    name: 'IUmbrella',
-  },
-  {
-    address: '0x75e8aC0c063B6966E2A9954adEdf39BdE9370197',
     name: 'IUmbrellaStakeToken',
+    target: 'src/interfaces/IUmbrellaStakeToken.sol:IUmbrellaStakeToken',
+  },
+  {
+    name: 'IVotingMachineDataHelper',
+    target: 'src/interfaces/IVotingMachineDataHelper.sol:IVotingMachineDataHelper',
+  },
+  {
+    name: 'IWrappedTokenGatewayV3',
+    target: 'lib/aave-v3-origin/src/contracts/helpers/interfaces/IWrappedTokenGatewayV3.sol',
   },
 ];

--- a/scripts/generateABIs.ts
+++ b/scripts/generateABIs.ts
@@ -1,52 +1,45 @@
-import util from 'node:util';
-import {exec} from 'node:child_process';
-import {existsSync, mkdirSync, rmSync, writeFileSync} from 'node:fs';
+import {execFile} from 'node:child_process';
+import {mkdirSync, mkdtempSync, renameSync, rmSync, writeFileSync} from 'node:fs';
+import {dirname, join} from 'node:path';
+import {promisify} from 'node:util';
 import {prefixWithGeneratedWarning} from 'scripts/generator/utils';
-import {ABI_INTERFACES, DOWNLOAD_ABI_INTERFACES, resolveAbiInterface} from 'scripts/configs/abis';
+import {generateABIImports} from 'scripts/generator/abis';
+import {ABI_INTERFACES} from 'scripts/configs/abis';
 
-const awaitableExec = util.promisify(exec);
+const awaitableExecFile = promisify(execFile);
+const ABI_DIRECTORY = './src/ts/abis';
 
-export async function generateABIs(removeExisting: boolean) {
-  if (existsSync('./src/ts/abis')) {
-    if (removeExisting) {
-      rmSync('./src/ts/abis', {recursive: true});
-      mkdirSync('./src/ts/abis');
-    }
-  } else {
-    mkdirSync('./src/ts/abis');
-  }
-  for (const ENTRY of ABI_INTERFACES) {
-    const {path, name} = resolveAbiInterface(ENTRY);
-    const {stdout, stderr} = await awaitableExec(`forge inspect --json ${path} abi`);
-    if (stderr) {
-      throw new Error(`Failed to generate abi for ${name}`);
-    }
+export async function generateABIs(outputDirectory: string) {
+  mkdirSync(outputDirectory, {recursive: true});
+
+  for (const {name, target} of ABI_INTERFACES) {
+    const {stdout} = await awaitableExecFile('forge', ['inspect', '--json', target, 'abi']);
     const varName = `${name}_ABI`;
     writeFileSync(
-      `./src/ts/abis/${name}.ts`,
+      join(outputDirectory, `${name}.ts`),
       prefixWithGeneratedWarning(
         `export const ${varName} = ${JSON.stringify(JSON.parse(stdout.trim()), null, 2)} as const;`,
       ),
     );
   }
-  for (const INTERFACE of DOWNLOAD_ABI_INTERFACES) {
-    const fileName = `./src/ts/abis/${INTERFACE.name}.ts`;
-    if (existsSync(fileName)) {
-      console.log(`skipping download of abi ${INTERFACE.name} as it already exists`);
-      continue;
-    }
-    const {stdout, stderr} = await awaitableExec(`cast interface -j ${INTERFACE.address}`);
-    if (stderr) {
-      throw new Error(`Failed to generate abi for ${INTERFACE.name} from ${INTERFACE.address}`);
-    }
-    const varName = `${INTERFACE.name}_ABI`;
-    writeFileSync(
-      fileName,
-      prefixWithGeneratedWarning(
-        `export const ${varName} = ${JSON.stringify(JSON.parse(stdout.trim()), null, 2)} as const;`,
-      ),
-    );
+
+  writeFileSync(join(outputDirectory, 'index.ts'), `${generateABIImports().join('\n')}\n`);
+}
+
+async function replaceGeneratedABIs() {
+  mkdirSync(dirname(ABI_DIRECTORY), {recursive: true});
+  const stagingDirectory = mkdtempSync(join(dirname(ABI_DIRECTORY), '.abis-'));
+
+  try {
+    await generateABIs(stagingDirectory);
+    rmSync(ABI_DIRECTORY, {recursive: true, force: true});
+    renameSync(stagingDirectory, ABI_DIRECTORY);
+  } catch (error) {
+    rmSync(stagingDirectory, {recursive: true, force: true});
+    throw error;
   }
 }
 
-generateABIs(false);
+if (require.main === module) {
+  replaceGeneratedABIs();
+}

--- a/scripts/generator/abis.ts
+++ b/scripts/generator/abis.ts
@@ -1,14 +1,9 @@
-import {ABI_INTERFACES, DOWNLOAD_ABI_INTERFACES, resolveAbiInterface} from 'scripts/configs/abis';
+import {ABI_INTERFACES} from 'scripts/configs/abis';
 
 export function generateABIImports() {
   const jsExports: string[] = [];
-  for (const ENTRY of ABI_INTERFACES) {
-    const {name} = resolveAbiInterface(ENTRY);
+  for (const {name} of ABI_INTERFACES) {
     jsExports.push(`export {${name}_ABI} from './${name}';`);
-  }
-  for (const INTERFACE of DOWNLOAD_ABI_INTERFACES) {
-    const varName = `${INTERFACE.name}_ABI`;
-    jsExports.push(`export {${varName}} from './${INTERFACE.name}';`);
   }
   return jsExports;
 }


### PR DESCRIPTION
ABI generation mixed inferred Forge identifiers with explorer-backed entries, wrote directly into the published directory, and derived exports through two separate registries.

Register every published ABI with an explicit name and Solidity target, generate the ABI files and index from that registry, invoke Forge without shell interpolation, and replace the output atomically after generation succeeds. The Solidity targets introduced by this registry are supplied by the next PR in the stack.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
